### PR TITLE
Fixes some styles of the Tile component

### DIFF
--- a/src/components/Tiles/Tiles.js
+++ b/src/components/Tiles/Tiles.js
@@ -5,26 +5,25 @@ const hexToRgbA = (hex) => {
   /**
    * Converts hex color to rgba type that will used in box-shadow
    */
-  let r = parseInt(hex.slice(1, 3), 16);
-  let g = parseInt(hex.slice(3, 5), 16);
-  let b = parseInt(hex.slice(5, 7), 16);
+  let rgb = [
+    parseInt(hex.slice(1, 3), 16),
+    parseInt(hex.slice(3, 5), 16),
+    parseInt(hex.slice(5, 7), 16)
+  ];
 
-  return `rgba(${r}, ${g}, ${b}, 0.5)`;
+  return `rgba(${rgb.join()}, 0.5)`;
 }
 
-/**
- * Darken/Lighten color based on the percent
- */
-const darkenColor = (color, percent) => {
-  let f=parseInt(color.slice(1),16),t=percent<0?0:255,p=percent<0?percent*-1:percent,R=f>>16,G=f>>8&0x00FF,B=f&0x0000FF;
-  return "#"+(0x1000000+(Math.round((t-R)*p)+R)*0x10000+(Math.round((t-G)*p)+G)*0x100+(Math.round((t-B)*p)+B)).toString(16).slice(1);
+const darkenColor = (color) => {
+  const rgb = [color.substring(1,3), color.substring(3,5), color.substring(5,7)];
+  return `rgb(${rgb.map(c => Math.round((parseInt(c, 16) * 0.55))).join()})`;
 }
 
 const Tile = (props) => {
   const { color } = props;
   const tileStyles = {
     backgroundColor: color,
-    backgroundImage: `linear-gradient(135deg, ${color} 1%, ${darkenColor(color, -0.4)} 100%)`,
+    backgroundImage: `linear-gradient(135deg, ${color} 1%, ${darkenColor(color)} 100%)`,
     boxShadow: `0px 5px 30px ${hexToRgbA(color)}`
   }
   return(

--- a/src/components/Tiles/Tiles.js
+++ b/src/components/Tiles/Tiles.js
@@ -1,10 +1,31 @@
 import React from 'react';
 import './Tiles.css';
 
+const hexToRgbA = (hex) => {
+  /**
+   * Converts hex color to rgba type that will used in box-shadow
+   */
+  let r = parseInt(hex.slice(1, 3), 16);
+  let g = parseInt(hex.slice(3, 5), 16);
+  let b = parseInt(hex.slice(5, 7), 16);
+
+  return `rgba(${r}, ${g}, ${b}, 0.5)`;
+}
+
+/**
+ * Darken/Lighten color based on the percent
+ */
+const darkenColor = (color, percent) => {
+  let f=parseInt(color.slice(1),16),t=percent<0?0:255,p=percent<0?percent*-1:percent,R=f>>16,G=f>>8&0x00FF,B=f&0x0000FF;
+  return "#"+(0x1000000+(Math.round((t-R)*p)+R)*0x10000+(Math.round((t-G)*p)+G)*0x100+(Math.round((t-B)*p)+B)).toString(16).slice(1);
+}
+
 const Tile = (props) => {
-  const { backgroundColor } = props;
+  const { color } = props;
   const tileStyles = {
-    backgroundColor,
+    backgroundColor: color,
+    backgroundImage: `linear-gradient(135deg, ${color} 1%, ${darkenColor(color, -0.4)} 100%)`,
+    boxShadow: `0px 5px 30px ${hexToRgbA(color)}`
   }
   return(
     <div className="tile-style" style={tileStyles}>

--- a/src/components/Tiles/Tiles.scss
+++ b/src/components/Tiles/Tiles.scss
@@ -2,12 +2,16 @@
   width: 150px;
   height: 150px;
   border-radius: 5px;
-  box-shadow: 0px 0px 15px 0px;
-  padding-top: 65px;
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  margin: 0 10px;
 }
 
 .tile-span-style {
   color: white;
+  font-size: 20px;
   font-weight: 700;
 }


### PR DESCRIPTION
<!-- Add the issue number that is fixed by this PR (In the form Fixes #123) -->
Fixes #62 

#### Checklist

- [X] I have read the Contribution & Best practices Guide and my PR follows them.
- [X] My branch is up-to-date with the Upstream `master` branch.
- [ ] I have added/updated necessary tests/documentation (if applicable)

#### Changes proposed in this pull request:

- **Fixed the `box-shadow`** - converts the color passed to `rgba()` and sets it dynamically
- **Added `linear-gradient`** - uses a function from https://stackoverflow.com/a/13542669 to darken the color passed and set the background dynamically. Additionally, browsers that don't support `linear-gradient` would fallback to using `background-color`
- **Fixed spacing** - Centered the text using `inline-flex`, added spacing between adjacent tiles
